### PR TITLE
fix: remove node warning

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,3 @@
-import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 import { setupInspiraUI } from "@inspira-ui/plugins";
 
@@ -126,4 +125,4 @@ export default {
   },
 
   plugins: [animate, setupInspiraUI],
-} satisfies Config;
+};


### PR DESCRIPTION
This warning:
```
 ERROR  (node:244597) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.                                                               9:56:33 PM
(Use node --trace-warnings ... to show where the warning was created)
```